### PR TITLE
light/dark examples: respect-user-color-scheme, code-tools source links

### DIFF
--- a/renderings/_quarto.yml
+++ b/renderings/_quarto.yml
@@ -21,11 +21,12 @@ website:
       - pygal.qmd
       - seaborn.qmd
       - thematic.qmd
-
 brand:
   light: light-brand.yml
   dark: dark-brand.yml
-
 theme:
   light: brand
   dark: [brand, dark-fixups.scss]
+format:
+  html:
+    respect-user-color-scheme: true

--- a/renderings/altair.qmd
+++ b/renderings/altair.qmd
@@ -2,6 +2,10 @@
 title: altair
 engine: jupyter
 keep-md: true
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/altair.qmd
 ---
 
 

--- a/renderings/bokeh.qmd
+++ b/renderings/bokeh.qmd
@@ -2,6 +2,10 @@
 title: bokeh
 author: "anthropic claude-3-5-sonnet-latest"
 date: 2025-01-06
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/bokeh.qmd
 ---
 
 ## Question

--- a/renderings/flextable.qmd
+++ b/renderings/flextable.qmd
@@ -3,6 +3,10 @@ title: flextable
 execute:
   echo: false
   warning: false
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/flextable.qmd
 ---
 
 ```{r}

--- a/renderings/ggiraph.qmd
+++ b/renderings/ggiraph.qmd
@@ -1,5 +1,9 @@
 ---
 title: ggiraph
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/ggiraph.qmd
 ---
 
 ```{r}

--- a/renderings/ggplot.qmd
+++ b/renderings/ggplot.qmd
@@ -1,6 +1,10 @@
 ---
 title: ggplot
 keep-md: true
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/ggplot.qmd
 ---
 
 ```{r}

--- a/renderings/great-tables.qmd
+++ b/renderings/great-tables.qmd
@@ -3,6 +3,10 @@ title: great tables
 engine: jupyter
 keep-md: true
 ipynb-shell-interactivity: all
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/great-tables.qmd
 ---
 
 ```{python}

--- a/renderings/gt.qmd
+++ b/renderings/gt.qmd
@@ -3,6 +3,10 @@ title: gt
 execute:
   echo: false
   warning: false
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/gt.qmd
 ---
 
 ```{r}

--- a/renderings/heatmaply.qmd
+++ b/renderings/heatmaply.qmd
@@ -1,5 +1,9 @@
 ---
 title: heatmaply
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/heatmaply.qmd
 ---
 
 Note, this is not fully working - see e.g. the legend background and the labels.

--- a/renderings/leaflet.qmd
+++ b/renderings/leaflet.qmd
@@ -1,5 +1,9 @@
 ---
 title: leaflet
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/leaflet.qmd
 ---
 
 ```{r}

--- a/renderings/matplotlib.qmd
+++ b/renderings/matplotlib.qmd
@@ -2,6 +2,10 @@
 title: matplotlib
 engine: jupyter
 keep-md: true
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/matplotlib.qmd
 ---
 
 ```{python}

--- a/renderings/plotly-python.qmd
+++ b/renderings/plotly-python.qmd
@@ -2,6 +2,10 @@
 title: plotly-python
 author: "openai gpt-4o"
 date: "2024-10-23 16:52:22.554560"
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/plotly-python.qmd
 ---
 
 # Question

--- a/renderings/plotly-r.qmd
+++ b/renderings/plotly-r.qmd
@@ -3,6 +3,10 @@ title: plotly-r
 execute:
   echo: false
   warning: false
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/plotly-r.qmd
 ---
 
 ```{r}

--- a/renderings/plotnine.qmd
+++ b/renderings/plotnine.qmd
@@ -5,6 +5,10 @@ date: "2025-01-22 14:25:54.403762"
 engine: jupyter
 keep-md: true
 ipynb-shell-interactivity: all
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/plotnine.qmd
 ---
 
 ## Question

--- a/renderings/pygal.qmd
+++ b/renderings/pygal.qmd
@@ -2,6 +2,10 @@
 title: pygal
 engine: jupyter
 keep-md: true
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/pygal.qmd
 ---
 
 ```{python}

--- a/renderings/seaborn.qmd
+++ b/renderings/seaborn.qmd
@@ -4,6 +4,10 @@ engine: jupyter
 keep-md: true
 author: "openai gpt-4o"
 date: 2024-12-25 18:31:06.502548
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/seaborn.qmd
 ---
 
 # How to Draw a Violin Plot of the Iris Data Using Seaborn

--- a/renderings/thematic.qmd
+++ b/renderings/thematic.qmd
@@ -3,6 +3,10 @@ title: thematic
 execute:
   echo: false
   warning: false
+format:
+  html:
+    code-tools:
+      source: https://github.com/quarto-dev/quarto-examples/blob/main/renderings/thematic.qmd
 ---
 
 ```{r}


### PR DESCRIPTION
The source buttons don't work on quarto-pub, but I think this is worth doing anyway.

Also adds `respect-user-color-scheme` because that's the best practice, even if a little weird in an iframe.