### PR TITLE
remove workaround for plotly renderings example

### DIFF
--- a/renderings/plotly-python.qmd
+++ b/renderings/plotly-python.qmd
@@ -28,7 +28,7 @@ pio.templates['dark_brand'] = theme_brand_plotly('dark-brand.yml')
 
 ```{python}
 #| echo: false
-#| renderings: [foo, light, dark]
+#| renderings: [light, dark]
 # plotly 6.* has three outputs the first time you run it.
 # without "foo" you'll get the warning
 # (W) need 2 cell-output-display for renderings light,dark; got 3


### PR DESCRIPTION
To be merged after quarto-dev/quarto-cli#12842

The `foo` workaround is no longer necessary (and now breaks).

Revert to `renderings: [light, dark]`