### PR TITLE
chore: show code in flextable example

### DIFF
--- a/renderings/flextable.qmd
+++ b/renderings/flextable.qmd
@@ -1,7 +1,7 @@
 ---
 title: flextable
 execute:
-  echo: false
+  echo: true
   warning: false
 format:
   html:


### PR DESCRIPTION
The other examples (https://examples.quarto.pub/lightdark-renderings-examples/ggplot2.html) include code, but it's currently missing in https://examples.quarto.pub/lightdark-renderings-examples/flextable.html